### PR TITLE
[Milky] Fix MentionAll display

### DIFF
--- a/Lagrange.Milky/Utility/EntityConvert.Segment.cs
+++ b/Lagrange.Milky/Utility/EntityConvert.Segment.cs
@@ -87,7 +87,7 @@ public partial class EntityConvert
     {
         TextOutgoingSegment text => new TextEntity(text.Data.Text),
         MentionOutgoingSegment mention => new MentionEntity(mention.Data.UserId, null),
-        MentionAllOutgoingSegment => new MentionEntity(0, null),
+        MentionAllOutgoingSegment => new MentionEntity(0, "@全体成员"),
         // TODO
         FaceOutgoingSegment => throw new NotImplementedException(),
         // ReplySegment => 


### PR DESCRIPTION
```log
dbug: Lagrange.Milky.Api.MilkyHttpApiService[1]
      00000000-0000-0000-2400-0040020000ff 127.0.0.1:60617 -->> POST /api/send_group_message
dbug: Lagrange.Milky.Api.MilkyHttpApiService[2]
      00000000-0000-0000-2400-0040020000ff 127.0.0.1:60617 -->> {"group_id": <group_id>, "message": [{"type": "mention_all", "data": {}}]}
trce: Lagrange.Core.Internal.Context.ServiceContext[0]
      Outgoing SSOFrame: MessageSvc.PbSendMsg
fail: Lagrange.Milky.Api.MilkyHttpApiService[996]
      00000000-0000-0000-2400-0040020000ff 127.0.0.1:60617 <!!> Handle api failed
      Lagrange.Core.Exceptions.LagrangeException: An error occurred while sending the event
       ---> System.InvalidOperationException: Display cannot be null
         at Lagrange.Core.Message.Entities.MentionEntity.Lagrange.Core.Message.Entities.IMessageEntity.Build()
         at Lagrange.Core.Message.MessagePacker.Build(BotMessage message)
         at Lagrange.Core.Internal.Services.Message.SendMessageService.Build(ProtocolEvent input, BotContext context)
         at Lagrange.Core.Internal.Services.BaseService`2.Lagrange.Core.Internal.Services.IService.Build(ProtocolEvent input, BotContext context)
         at Lagrange.Core.Internal.Context.ServiceContext.Resolve(ProtocolEvent event)
         at Lagrange.Core.Internal.Context.EventContext.SendEvent[T](ProtocolEvent event)
         --- End of inner exception stack trace ---
         at Lagrange.Core.Internal.Context.EventContext.SendEvent[T](ProtocolEvent event)
         at Lagrange.Core.Internal.Logic.MessagingLogic.SendGroupMessage(Int64 groupUin, MessageChain chain)
         at Lagrange.Milky.Api.Handler.Message.SendGroupMessageHandler.HandleAsync(SendGroupMessageParameter parameter, CancellationToken token)
         at Lagrange.Milky.Api.Handler.IApiHandler`2.Lagrange.Milky.Api.Handler.IApiHandler.HandleAsync(Object parameter, CancellationToken token)
         at Lagrange.Milky.Api.MilkyHttpApiService.GetResultAsync(HttpListenerContext context, IApiHandler handler, Object parameter, CancellationToken token)
dbug: Lagrange.Milky.Api.MilkyHttpApiService[4]
      00000000-0000-0000-2400-0040020000ff 127.0.0.1:60617 <<-- {"status":"failed","retcode":-400,"message":"Internal server error"}
```