### PR TITLE
[All] Implemented FetchGroupNotifications and its required APIs

### DIFF
--- a/Lagrange.Core/Common/Entity/BotGroupExitNotification.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupExitNotification.cs
@@ -1,0 +1,3 @@
+namespace Lagrange.Core.Common.Entity;
+
+public class BotGroupExitNotification(long group, ulong sequence, long target) : BotGroupNotificationBase(group, sequence, BotGroupNotificationType.Exit, target);

--- a/Lagrange.Core/Common/Entity/BotGroupInviteNotification.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupInviteNotification.cs
@@ -1,0 +1,10 @@
+namespace Lagrange.Core.Common.Entity;
+
+public class BotGroupInviteNotification(long group, ulong sequence, long target, BotGroupNotificationState state, long? @operator, long inviter) : BotGroupNotificationBase(group, sequence, BotGroupNotificationType.Invite, target)
+{
+    public BotGroupNotificationState State { get; } = state;
+
+    public long? Operator { get; } = @operator;
+
+    public long Inviter { get; } = inviter;
+}

--- a/Lagrange.Core/Common/Entity/BotGroupJoinNotification.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupJoinNotification.cs
@@ -1,0 +1,10 @@
+namespace Lagrange.Core.Common.Entity;
+
+public class BotGroupJoinNotification(long group, ulong sequence, long target, BotGroupNotificationState state, long? @operator, string comment) : BotGroupNotificationBase(group, sequence, BotGroupNotificationType.Join, target)
+{
+    public BotGroupNotificationState State { get; } = state;
+
+    public long? Operator { get; } = @operator;
+
+    public string Comment { get; } = comment;
+}

--- a/Lagrange.Core/Common/Entity/BotGroupKickNotification.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupKickNotification.cs
@@ -1,0 +1,6 @@
+namespace Lagrange.Core.Common.Entity;
+
+public class BotGroupKickNotification(long group, ulong sequence, long target, long @operator) : BotGroupNotificationBase(group, sequence, BotGroupNotificationType.Exit, target)
+{
+    public long Operator { get; } = @operator;
+}

--- a/Lagrange.Core/Common/Entity/BotGroupNotificationBase.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupNotificationBase.cs
@@ -1,0 +1,12 @@
+namespace Lagrange.Core.Common.Entity;
+
+public abstract class BotGroupNotificationBase(long group, ulong sequence, BotGroupNotificationType type, long target)
+{
+    public long Group { get; } = group;
+
+    public ulong Sequence { get; } = sequence;
+
+    public BotGroupNotificationType Type { get; } = type;
+
+    public long Target { get; } = target;
+}

--- a/Lagrange.Core/Common/Entity/BotGroupNotificationState.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupNotificationState.cs
@@ -1,0 +1,9 @@
+namespace Lagrange.Core.Common.Entity;
+
+public enum BotGroupNotificationState
+{
+    Wait = 1,
+    Accept,
+    Reject,
+    Ignore
+}

--- a/Lagrange.Core/Common/Entity/BotGroupNotificationType.cs
+++ b/Lagrange.Core/Common/Entity/BotGroupNotificationType.cs
@@ -1,0 +1,10 @@
+namespace Lagrange.Core.Common.Entity;
+
+public enum BotGroupNotificationType
+{
+    Join = 1,
+    Exit = 13,
+    KickOther = 6,
+    KickSelf = 7,
+    Invite = 22
+}

--- a/Lagrange.Core/Common/Entity/BotStranger.cs
+++ b/Lagrange.Core/Common/Entity/BotStranger.cs
@@ -1,12 +1,43 @@
 namespace Lagrange.Core.Common.Entity;
 
-public class BotStranger(long uin, string nickname, string uid) : BotContact
+public class BotStranger(long uin, string nickname, string uid, string personalSign, string remark, ulong level, BotGender gender, DateTime registrationTime, DateTime? birthday, ulong age, string qID) : BotContact
 {
     public override long Uin { get; } = uin;
-    
+
     public override string Nickname { get; } = nickname ?? string.Empty;
-    
+
     public override string Uid { get; } = uid ?? string.Empty;
-    
+
+    public string PersonalSign { get; } = personalSign;
+
+    public string Remark { get; } = remark;
+
+    public ulong Level { get; } = level;
+
+    public BotGender Gender { get; } = gender;
+
+    public DateTime RegistrationTime { get; } = registrationTime;
+
+    public DateTime? Birthday { get; } = birthday;
+
+    public ulong Age { get; } = age;
+
+    public string QID { get; } = qID;
+
     public long Source { get; init; }
+
+    internal BotStranger CloneWithSource(long source) => new(
+        Uin,
+        Nickname,
+        Uid,
+        PersonalSign,
+        Remark,
+        Level,
+        Gender,
+        RegistrationTime,
+        Birthday,
+        Age,
+        QID
+    )
+    { Source = source };
 }

--- a/Lagrange.Core/Common/Interface/OperationExt.cs
+++ b/Lagrange.Core/Common/Interface/OperationExt.cs
@@ -6,15 +6,15 @@ namespace Lagrange.Core.Common.Interface;
 
 public static class OperationExt
 {
-    public static Task<BotQrCodeInfo?> FetchQrCodeInfo(this BotContext context, byte[] k) => 
+    public static Task<BotQrCodeInfo?> FetchQrCodeInfo(this BotContext context, byte[] k) =>
         context.EventContext.GetLogic<WtExchangeLogic>().FetchQrCodeInfo(k);
-    
+
     public static Task<(bool Success, string Message)> CloseQrCode(this BotContext context, byte[] k, bool confirm) =>
         context.EventContext.GetLogic<WtExchangeLogic>().CloseQrCode(k, confirm);
-    
+
     public static Task<Dictionary<string, string>> FetchCookies(this BotContext context, params List<string> domains) =>
         context.EventContext.GetLogic<OperationLogic>().FetchCookies(domains);
-    
+
     public static Task<(string Key, uint Expiration)> FetchClientKey(this BotContext context) =>
         context.EventContext.GetLogic<OperationLogic>().FetchClientKey();
 
@@ -26,4 +26,10 @@ public static class OperationExt
 
     public static Task<List<BotGroupMember>> FetchMembers(this BotContext context, long groupUin, bool refresh = false) =>
         context.CacheContext.GetMemberList(groupUin, refresh);
+
+    public static Task<List<BotGroupNotificationBase>> FetchGroupNotifications(this BotContext context, ulong count) =>
+        context.EventContext.GetLogic<OperationLogic>().FetchGroupNotifications(count);
+
+    public static Task<BotStranger> FetchStranger(this BotContext context, long uin) =>
+        context.EventContext.GetLogic<OperationLogic>().FetchStranger(uin);
 }

--- a/Lagrange.Core/Internal/Events/System/FetchGroupNotificationsEvent.cs
+++ b/Lagrange.Core/Internal/Events/System/FetchGroupNotificationsEvent.cs
@@ -1,0 +1,14 @@
+using System.Diagnostics.CodeAnalysis;
+using Lagrange.Core.Common.Entity;
+
+namespace Lagrange.Core.Internal.Events.System;
+
+internal class FetchGroupNotificationsEventReq(ulong count) : ProtocolEvent
+{
+    public ulong Count { get; } = count;
+}
+
+internal class FetchGroupNotificationsEventResp(List<BotGroupNotificationBase> groupNotifications) : ProtocolEvent
+{
+    public List<BotGroupNotificationBase> GroupNotifications { get; } = groupNotifications;
+}

--- a/Lagrange.Core/Internal/Events/System/FetchStrangerEvent.cs
+++ b/Lagrange.Core/Internal/Events/System/FetchStrangerEvent.cs
@@ -1,0 +1,20 @@
+using Lagrange.Core.Common.Entity;
+
+namespace Lagrange.Core.Internal.Events.System;
+
+internal abstract class FetchStrangerEventReqBase : ProtocolEvent { }
+
+internal class FetchStrangerByUinEventReq(long uin) : FetchStrangerEventReqBase
+{
+    public long Uin { get; } = uin;
+}
+
+internal class FetchStrangerByUidEventReq(string uid) : FetchStrangerEventReqBase
+{
+    public string Uid { get; } = uid;
+}
+
+internal class FetchStrangerEventResp(BotStranger stranger) : ProtocolEvent
+{
+    public BotStranger Stranger { get; } = stranger;
+}

--- a/Lagrange.Core/Internal/Logic/PushLogic.cs
+++ b/Lagrange.Core/Internal/Logic/PushLogic.cs
@@ -32,8 +32,8 @@ internal class PushLogic(BotContext context) : ILogic
                     context.EventInvoker.PostEvent(
                         new BotGroupMemberDecreaseEvent(
                             decrease.GroupUin,
-                            context.CacheContext.ResolveCachedUin(decrease.MemberUid) ?? 0,
-                            context.CacheContext.ResolveCachedUin(op.Operator.Uid ?? "") ?? 0
+                            context.CacheContext.ResolveUin(decrease.MemberUid),
+                            context.CacheContext.ResolveUin(op.Operator.Uid ?? "")
                         )
                     );
                 }
@@ -42,8 +42,8 @@ internal class PushLogic(BotContext context) : ILogic
                     context.EventInvoker.PostEvent(
                         new BotGroupMemberDecreaseEvent(
                             decrease.GroupUin,
-                            context.CacheContext.ResolveCachedUin(decrease.MemberUid) ?? 0,
-                            context.CacheContext.ResolveCachedUin(Encoding.UTF8.GetString(decrease.Operator.AsSpan())) ?? 0
+                            context.CacheContext.ResolveUin(decrease.MemberUid),
+                            context.CacheContext.ResolveUin(Encoding.UTF8.GetString(decrease.Operator.AsSpan()))
                         )
                     );
                 }

--- a/Lagrange.Core/Internal/Network/ClientListener.cs
+++ b/Lagrange.Core/Internal/Network/ClientListener.cs
@@ -152,7 +152,9 @@ internal abstract partial class ClientListener : IClientListener
                 
                 try
                 {
-                    OnRecvPacket(buffer.AsSpan(0, packetLength));
+                    var packet = new byte[packetLength];
+                    buffer.AsSpan(0, packetLength).CopyTo(packet);
+                    OnRecvPacket(packet);
                 }
                 catch (Exception e)
                 {

--- a/Lagrange.Core/Internal/Packets/Service/FetchGroupNotifications.cs
+++ b/Lagrange.Core/Internal/Packets/Service/FetchGroupNotifications.cs
@@ -1,0 +1,52 @@
+using Lagrange.Proto;
+
+namespace Lagrange.Core.Internal.Packets.Service;
+
+#pragma warning disable CS8618
+
+[ProtoPackable]
+internal partial class FetchGroupNotificationsRequest
+{
+    [ProtoMember(1)] public ulong Count { get; set; }
+}
+
+
+[ProtoPackable]
+internal partial class FetchGroupNotificationsResponse
+{
+    [ProtoMember(1)] public List<FetchGroupNotificationsResponseNotification> GroupNotifications { get; set; }
+}
+
+[ProtoPackable]
+public partial class FetchGroupNotificationsResponseNotification
+{
+    [ProtoMember(1)] public ulong Sequence { get; set; }
+
+    // 1 join 6 kick other(no state) 7 kick self(no state) 13 exit(no state) 22 invite
+    [ProtoMember(2)] public ulong Type { get; set; }
+
+    // 1 wait 2 accept 3 reject 4 ignore
+    [ProtoMember(3)] public ulong State { get; set; }
+
+    [ProtoMember(4)] public FetchGroupNotificationsResponseNotificationGroup Group { get; set; }
+
+    [ProtoMember(5)] public FetchGroupNotificationsResponseNotificationUser Target { get; set; }
+
+    [ProtoMember(6)] public FetchGroupNotificationsResponseNotificationUser Inviter { get; set; }
+
+    [ProtoMember(7)] public FetchGroupNotificationsResponseNotificationUser Operator { get; set; }
+
+    [ProtoMember(10)] public string Comment { get; set; }
+}
+
+[ProtoPackable]
+public partial class FetchGroupNotificationsResponseNotificationGroup
+{
+    [ProtoMember(1)] public long GroupUin { get; set; }
+}
+
+[ProtoPackable]
+public partial class FetchGroupNotificationsResponseNotificationUser
+{
+    [ProtoMember(1)] public string Uid { get; set; }
+}

--- a/Lagrange.Core/Internal/Packets/Service/FetchStranger.cs
+++ b/Lagrange.Core/Internal/Packets/Service/FetchStranger.cs
@@ -1,0 +1,66 @@
+using Lagrange.Proto;
+
+namespace Lagrange.Core.Internal.Packets.Service;
+
+#pragma warning disable CS8618
+
+[ProtoPackable]
+internal partial class FetchStrangerByUidRequest
+{
+    [ProtoMember(1)] public string Uid { get; set; }
+
+    [ProtoMember(3)] public List<FetchStrangerRequestKey> Keys { get; set; }
+}
+
+[ProtoPackable]
+internal partial class FetchStrangerByUinRequest
+{
+    [ProtoMember(1)] public long Uin { get; set; }
+
+    [ProtoMember(3)] public List<FetchStrangerRequestKey> Keys { get; set; }
+}
+
+[ProtoPackable]
+internal partial class FetchStrangerRequestKey
+{
+    [ProtoMember(1)] public ulong Key { get; set; }
+}
+
+
+[ProtoPackable]
+internal partial class FetchStrangerResponse
+{
+    [ProtoMember(1)] public FetchStrangerResponseBody Body { get; set; }
+}
+
+[ProtoPackable]
+internal partial class FetchStrangerResponseBody
+{
+    [ProtoMember(2)] public FetchStrangerResponseProperties Properties { get; set; }
+
+    [ProtoMember(3)] public uint Uin { get; set; }
+}
+
+[ProtoPackable]
+public partial class FetchStrangerResponseProperties
+{
+    [ProtoMember(1)] public List<FetchStrangerResponseNumberProperties> NumberProperties { get; set; }
+
+    [ProtoMember(2)] public List<FetchStrangerResponseBytesProperties> BytesProperties { get; set; }
+}
+
+[ProtoPackable]
+public partial class FetchStrangerResponseNumberProperties
+{
+    [ProtoMember(1)] public ulong Key { get; set; }
+
+    [ProtoMember(2)] public ulong Value { get; set; }
+}
+
+[ProtoPackable]
+public partial class FetchStrangerResponseBytesProperties
+{
+    [ProtoMember(1)] public ulong Key { get; set; }
+
+    [ProtoMember(2)] public byte[] Value { get; set; }
+}

--- a/Lagrange.Core/Internal/Packets/Struct/SsoPacket.cs
+++ b/Lagrange.Core/Internal/Packets/Struct/SsoPacket.cs
@@ -17,10 +17,13 @@ internal class SsoPacket(string command, int sequence, int retCode, string extra
     public SsoPacket(string command, ReadOnlyMemory<byte> data, int sequence) : this(command, sequence, 0, string.Empty) => Data = data;
 }
 
-internal class SsoPacketValueTaskSource : IValueTaskSource<SsoPacket> 
+internal class SsoPacketValueTaskSource : IValueTaskSource<SsoPacket>
 {
-    private ManualResetValueTaskSourceCore<SsoPacket> _core;
-    
+    private ManualResetValueTaskSourceCore<SsoPacket> _core = new()
+    {
+        RunContinuationsAsynchronously = true,
+    };
+
     public SsoPacket GetResult(short token) => _core.GetResult(token);
 
     public ValueTaskSourceStatus GetStatus(short token) => _core.GetStatus(token);

--- a/Lagrange.Core/Internal/Services/OidbService.cs
+++ b/Lagrange.Core/Internal/Services/OidbService.cs
@@ -19,6 +19,8 @@ internal abstract class OidbService<TEventReq, TEventResp, TRequest, TResponse> 
     
     private protected abstract uint Service { get; }
 
+    private protected virtual uint Reserved { get; } = 0;
+
     private string Tag => $"OidbSvcTrpcTcp.0x{Command:X}_{Service}";
     
     private protected abstract Task<TRequest> ProcessRequest(TEventReq request, BotContext context);
@@ -41,6 +43,6 @@ internal abstract class OidbService<TEventReq, TEventResp, TRequest, TResponse> 
     {
         var request = await ProcessRequest(input, context);
         var proto = ProtoHelper.Serialize(request);
-        return ProtoHelper.Serialize(new Oidb { Command = Command, Service = Service, Body = proto });
+        return ProtoHelper.Serialize(new Oidb { Command = Command, Service = Service, Body = proto, Reserved = Reserved });
     }
 }

--- a/Lagrange.Core/Internal/Services/System/FetchGroupNotificationsService.cs
+++ b/Lagrange.Core/Internal/Services/System/FetchGroupNotificationsService.cs
@@ -1,0 +1,72 @@
+using Lagrange.Core.Common;
+using Lagrange.Core.Common.Entity;
+using Lagrange.Core.Internal.Events;
+using Lagrange.Core.Internal.Events.System;
+using Lagrange.Core.Internal.Packets.Service;
+
+namespace Lagrange.Core.Internal.Services.System;
+
+[EventSubscribe<FetchGroupNotificationsEventReq>(Protocols.All)]
+[Service("OidbSvcTrpcTcp.0x10c0_1")]
+internal class FetchGroupNotificationsService : OidbService<FetchGroupNotificationsEventReq, FetchGroupNotificationsEventResp, FetchGroupNotificationsRequest, FetchGroupNotificationsResponse>
+{
+    private protected override uint Command => 0x10c0;
+
+    private protected override uint Service => 1;
+
+    private protected override Task<FetchGroupNotificationsRequest> ProcessRequest(FetchGroupNotificationsEventReq request, BotContext context)
+    {
+        return Task.FromResult(new FetchGroupNotificationsRequest
+        {
+            Count = request.Count
+        });
+    }
+
+    private protected override Task<FetchGroupNotificationsEventResp> ProcessResponse(FetchGroupNotificationsResponse response, BotContext context)
+    {
+        List<BotGroupNotificationBase> notifications = [];
+        foreach (var request in response.GroupNotifications)
+        {
+            var target = context.CacheContext.ResolveUin(request.Target.Uid);
+            long? @operator = request.Operator != null
+                ? context.CacheContext.ResolveUin(request.Operator.Uid)
+                : null;
+            long? inviter = request.Inviter != null
+                ? context.CacheContext.ResolveUin(request.Inviter.Uid)
+                : null;
+
+            notifications.Add(request.Type switch
+            {
+                1 => new BotGroupJoinNotification(
+                    request.Group.GroupUin,
+                    request.Sequence,
+                    target,
+                    (BotGroupNotificationState)request.State,
+                    @operator,
+                    request.Comment
+                ),
+                6 or 7 => new BotGroupKickNotification(
+                    request.Group.GroupUin,
+                    request.Sequence,
+                    target,
+                    @operator ?? 0
+                ),
+                13 => new BotGroupExitNotification(
+                    request.Group.GroupUin,
+                    request.Sequence,
+                    target
+                ),
+                22 => new BotGroupInviteNotification(
+                    request.Group.GroupUin,
+                    request.Sequence,
+                    target,
+                    (BotGroupNotificationState)request.State,
+                    @operator,
+                    inviter ?? 0
+                ),
+                _ => throw new NotImplementedException(),
+            });
+        }
+        return Task.FromResult(new FetchGroupNotificationsEventResp(notifications));
+    }
+}

--- a/Lagrange.Core/Internal/Services/System/FetchStrangerService.cs
+++ b/Lagrange.Core/Internal/Services/System/FetchStrangerService.cs
@@ -1,0 +1,114 @@
+using System.Buffers.Binary;
+using System.Text;
+using Lagrange.Core.Common;
+using Lagrange.Core.Common.Entity;
+using Lagrange.Core.Exceptions;
+using Lagrange.Core.Internal.Events;
+using Lagrange.Core.Internal.Events.System;
+using Lagrange.Core.Internal.Packets.Service;
+using Lagrange.Core.Utility;
+
+namespace Lagrange.Core.Internal.Services.System;
+
+[EventSubscribe<FetchStrangerByUinEventReq>(Protocols.All)]
+[EventSubscribe<FetchStrangerByUidEventReq>(Protocols.All)]
+[Service("OidbSvcTrpcTcp.0xfe1_2")]
+internal class FetchStrangerService : BaseService<FetchStrangerEventReqBase, FetchStrangerEventResp>
+{
+    private static readonly uint Command = 0xfe1;
+
+    private static readonly uint Service = 2;
+
+    private static string Tag => $"OidbSvcTrpcTcp.0x{Command:X}_{Service}";
+
+    public static readonly List<FetchStrangerRequestKey> Keys = [
+        new() { Key = 101 },      // Avatar; Object
+        new() { Key = 102 },      // Sign
+        new() { Key = 103 },      // Remark
+        new() { Key = 104 },      // Tag; Object
+        new() { Key = 105 },      // Level
+        new() { Key = 107 },      // Business List; Object
+        new() { Key = 20002 },    // Nickname
+        new() { Key = 20003 },    // Country
+        new() { Key = 20004 },    // City
+        new() { Key = 20006 },    // Home City
+        new() { Key = 20009 },    // Gender; 1 Male 2 Female 255 Unknown
+        new() { Key = 20011 },    // EMail
+        new() { Key = 20016 },    // Desensitized mobile phone number
+        new() { Key = 20020 },    // Municipal district
+        new() { Key = 20021 },    // School
+        new() { Key = 20026 },    // Registration Time; Only year, hour, minute, second
+        new() { Key = 20031 },    // Birthday; 
+        new() { Key = 20037 },    // Age
+        new() { Key = 27394 },    // QID
+    ];
+
+    protected override ValueTask<ReadOnlyMemory<byte>> Build(FetchStrangerEventReqBase input, BotContext context)
+    {
+        return ValueTask.FromResult(input switch
+        {
+            FetchStrangerByUinEventReq req => ProtoHelper.Serialize(new Oidb
+            {
+                Command = Command,
+                Service = Service,
+                Body = ProtoHelper.Serialize(new FetchStrangerByUinRequest
+                {
+                    Uin = req.Uin,
+                    Keys = Keys,
+                }),
+                Reserved = 1
+            }),
+            FetchStrangerByUidEventReq req => ProtoHelper.Serialize(new Oidb
+            {
+                Command = Command,
+                Service = Service,
+                Body = ProtoHelper.Serialize(new FetchStrangerByUidRequest
+                {
+                    Uid = req.Uid,
+                    Keys = Keys,
+                })
+            }),
+            _ => throw new NotSupportedException(),
+        });
+    }
+
+    protected override ValueTask<FetchStrangerEventResp> Parse(ReadOnlyMemory<byte> input, BotContext context)
+    {
+        var oidb = ProtoHelper.Deserialize<Oidb>(input.Span);
+        if (oidb.Result != 0)
+        {
+            context.LogWarning(Tag, "Error: {0}, Message: {1}", null, oidb.Result, oidb.Message);
+            throw new OperationException((int)oidb.Result, oidb.Message);
+        }
+        var response = ProtoHelper.Deserialize<FetchStrangerResponse>(oidb.Body.Span);
+
+        var numbers = response.Body.Properties.NumberProperties.ToDictionary(
+            property => property.Key,
+            property => property.Value
+        );
+        var bytes = response.Body.Properties.BytesProperties.ToDictionary(
+            property => property.Key,
+            property => property.Value
+        );
+
+        // Birthday
+        byte[] birthday = bytes[20031];
+        int year = BinaryPrimitives.ReadUInt16BigEndian(birthday.AsSpan(0, 2));
+        int month = birthday[2];
+        int day = birthday[3];
+
+        return ValueTask.FromResult(new FetchStrangerEventResp(new BotStranger(
+            response.Body.Uin,
+            Encoding.UTF8.GetString(bytes[20002]),
+            string.Empty, // Can't not get uid
+            Encoding.UTF8.GetString(bytes[102]),
+            Encoding.UTF8.GetString(bytes[103]),
+            numbers[105],
+            (BotGender)numbers[20009],
+            DateTimeOffset.FromUnixTimeSeconds((long)numbers[20026]).DateTime,
+            month != 0 && day != 0 ? new DateTime(year != 0 ? year : 1, month, day) : null,
+            numbers[20037],
+            Encoding.UTF8.GetString(bytes[27394])
+        )));
+    }
+}

--- a/Lagrange.Core/Message/MessagePacker.cs
+++ b/Lagrange.Core/Message/MessagePacker.cs
@@ -87,10 +87,7 @@ internal class MessagePacker
                 return friend ?? new BotFriend(routingHead.FromUin, routingHead.FromUid, string.Empty, string.Empty, string.Empty, string.Empty, null!);
 
             case 141:
-                return new BotStranger(routingHead.FromUin, "", routingHead.FromUid)
-                {
-                    Source = routingHead.CommonC2C.FromTinyId
-                };
+                return (await _context.CacheContext.ResolveStranger(routingHead.ToUid)).CloneWithSource(routingHead.CommonC2C.FromTinyId);
             case 82:
                 var items = await _context.CacheContext.ResolveMember(routingHead.Group.GroupCode, routingHead.FromUin);
                 if (items != null) return items.Value.Item2;
@@ -116,10 +113,7 @@ internal class MessagePacker
 
                 return friend;
             case 141:
-                return new BotStranger(routingHead.ToUin, "", routingHead.ToUid)
-                {
-                    Source = routingHead.CommonC2C.FromTinyId
-                };
+                return (await _context.CacheContext.ResolveStranger(routingHead.ToUid)).CloneWithSource(routingHead.CommonC2C.FromTinyId);
             case 82:
                 var items = await _context.CacheContext.ResolveMember(routingHead.Group.GroupCode, routingHead.ToUin);
                 if (items == null)


### PR DESCRIPTION
Thanks for the review. Please feel free to point out any inaccuracies.

Specific modifications:

1. Implemented FetchStranger via uin and uid
2. Implemented FetchGroupNotifications
3. Extended BotStranger
4. Make package processing asynchronous In order to continue sending packets while parsing the packet
5. Created a cache for BotStranger


The modification in [ClientListener.cs](https://github.com/A-n-o-n-0/LagrangeV2/blob/e3193d70afdab1c5d625cd668a39d9471ca79fb7/Lagrange.Core/Internal/Network/ClientListener.cs#L155-L156) was necessitated by the transition of the packet handler to asynchronous processing ([SsoPacket.cs](https://github.com/A-n-o-n-0/LagrangeV2/blob/e3193d70afdab1c5d625cd668a39d9471ca79fb7/Lagrange.Core/Internal/Packets/Struct/SsoPacket.cs#L22)), requiring packet copying to prevent modification during subsequent packet handling.

This shift to asynchronous processing in [SsoPacket.cs](https://github.com/A-n-o-n-0/LagrangeV2/blob/e3193d70afdab1c5d625cd668a39d9471ca79fb7/Lagrange.Core/Internal/Packets/Struct/SsoPacket.cs#L22) was implemented because the logic in [FetchGroupNotificationsService.cs](https://github.com/A-n-o-n-0/LagrangeV2/blob/e3193d70afdab1c5d625cd668a39d9471ca79fb7/Lagrange.Core/Internal/Services/System/FetchGroupNotificationsService.cs#L30) requires sending additional packets during packet processing. Crucially, since the `ManualResetValueTaskSourceCore<>` operates synchronously by default, synchronous execution would cause the sent packets to be unable to receive responses due to Socket blocking, resulting in a deadlock from mutual blocking.