### PR TITLE
[Proto] Support polymorphic serialization for derived classes

### DIFF
--- a/Lagrange.Proto.Test/ProtoPolymorphismTest.cs
+++ b/Lagrange.Proto.Test/ProtoPolymorphismTest.cs
@@ -1,0 +1,58 @@
+﻿using Lagrange.Proto.Serialization;
+
+namespace Lagrange.Proto.Test;
+
+[TestFixture]
+public class ProtoPolymorphismTest
+{
+    #region Basic Polymorphism
+
+    [Test]
+    public void BasicPolymorphism_SerializeAndDeserialize_ReturnsCorrectDerivedType()
+    {
+        // Arrange
+        BaseClass original = new DerivedClassA { NameProperty = "TestName" };
+
+        byte[] bytes = ProtoSerializer.Serialize(original);
+        BaseClass deserialized = ProtoSerializer.Deserialize<BaseClass>(bytes);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(deserialized, Is.AssignableTo<DerivedClassA>());
+            Assert.That(deserialized, Is.AssignableTo<BaseClass>());
+            Assert.That(deserialized.IdentifierProperty, Is.EqualTo(2));
+            Assert.That(((DerivedClassA)deserialized).NameProperty, Is.EqualTo("TestName"));
+        });
+    }
+
+    #endregion
+}
+
+#region Test Classes
+
+[ProtoPolymorphic(FieldNumber = 1)]
+[ProtoDerivedType(typeof(DerivedClassA), 2)]
+[ProtoDerivedType(typeof(DerivedClassB), 3)]
+public class BaseClass
+{
+    public BaseClass() : this(-1) { }
+
+    public BaseClass(int identifier)
+    {
+        IdentifierProperty = identifier;
+    }
+
+    [ProtoMember(1)] public int IdentifierProperty { get; set; }
+}
+
+public class DerivedClassA() : BaseClass(2)
+{
+    [ProtoMember(2)] public string NameProperty { get; set; }
+}
+
+public class DerivedClassB() : BaseClass(3)
+{
+    [ProtoMember(2)] public float ValueProperty { get; set; }
+}
+
+#endregion

--- a/Lagrange.Proto/ProtoDerivedTypeAttribute.cs
+++ b/Lagrange.Proto/ProtoDerivedTypeAttribute.cs
@@ -1,0 +1,32 @@
+﻿namespace Lagrange.Proto;
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = true, Inherited = false)]
+public class ProtoDerivedTypeAttribute : Attribute
+{
+    public ProtoDerivedTypeAttribute(Type derivedType)
+    {
+        DerivedType = derivedType;
+    }
+
+    public ProtoDerivedTypeAttribute(Type derivedType, string typeDiscriminator)
+    {
+        DerivedType = derivedType;
+        TypeDiscriminator = typeDiscriminator;
+    }
+    
+    public ProtoDerivedTypeAttribute(Type derivedType, int typeDiscriminator)
+    {
+        DerivedType = derivedType;
+        TypeDiscriminator = typeDiscriminator;
+    }
+
+    /// <summary>
+    /// A derived type that should be supported in polymorphic serialization of the declared base type.
+    /// </summary>
+    public Type DerivedType { get; init; }
+ 
+    /// <summary>
+    /// The type discriminator identifier to be used for the serialization of the subtype.
+    /// </summary>
+    public object? TypeDiscriminator { get; init; }
+}

--- a/Lagrange.Proto/ProtoPolymorphicAttribute.cs
+++ b/Lagrange.Proto/ProtoPolymorphicAttribute.cs
@@ -5,4 +5,5 @@
 public class ProtoPolymorphicAttribute : Attribute
 {
     public uint FieldNumber { get; init; }
+    public bool FallbackToBaseType { get; init; } = true;
 }

--- a/Lagrange.Proto/ProtoPolymorphicAttribute.cs
+++ b/Lagrange.Proto/ProtoPolymorphicAttribute.cs
@@ -1,0 +1,8 @@
+﻿namespace Lagrange.Proto;
+
+
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Interface, AllowMultiple = false, Inherited = false)]
+public class ProtoPolymorphicAttribute : Attribute
+{
+    public uint FieldNumber { get; init; }
+}

--- a/Lagrange.Proto/Serialization/Metadata/ProtoObjectInfo.cs
+++ b/Lagrange.Proto/Serialization/Metadata/ProtoObjectInfo.cs
@@ -11,5 +11,6 @@ public class ProtoObjectInfo<T>
     
     public bool IgnoreDefaultFields { get; init; }
     public uint PolymorphicIndicateIndex { get; init; } = 0;
+    public bool PolymorphicFallbackToBaseType { get; init; } = true;
     public Dictionary<object, (Func<T>? objectCreator,Dictionary<uint, ProtoFieldInfo> fields)>? PolymorphicFields { get; init; }
 }

--- a/Lagrange.Proto/Serialization/Metadata/ProtoObjectInfo.cs
+++ b/Lagrange.Proto/Serialization/Metadata/ProtoObjectInfo.cs
@@ -10,4 +10,6 @@ public class ProtoObjectInfo<T>
     public Func<T>? ObjectCreator { get; init; }
     
     public bool IgnoreDefaultFields { get; init; }
+    public uint PolymorphicIndicateIndex { get; init; } = 0;
+    public Dictionary<object, (Func<T>? objectCreator,Dictionary<uint, ProtoFieldInfo> fields)>? PolymorphicFields { get; init; }
 }

--- a/Lagrange.Proto/Serialization/Metadata/ProtoTypeResolver.Dynamic.cs
+++ b/Lagrange.Proto/Serialization/Metadata/ProtoTypeResolver.Dynamic.cs
@@ -69,7 +69,9 @@ public static partial class ProtoTypeResolver
         var fields = CreateTypeFieldInfo(typeof(T));
         
         var polymorphicAttributes = typeof(T).GetCustomAttributes<ProtoDerivedTypeAttribute>().ToArray();
-        var polymorphicFieldNumber = typeof(T).GetCustomAttribute<ProtoPolymorphicAttribute>()?.FieldNumber ?? 0;
+        var polymorphicConfigAttribute = typeof(T).GetCustomAttribute<ProtoPolymorphicAttribute>();
+        var polymorphicFieldNumber =    polymorphicConfigAttribute?.FieldNumber ?? 0;
+        var fallbackToBaseType = polymorphicConfigAttribute?.FallbackToBaseType ?? true;
         
         if (polymorphicAttributes.Length > 0)
         {
@@ -90,6 +92,7 @@ public static partial class ProtoTypeResolver
                 ObjectCreator = MemberAccessor.CreateParameterlessConstructor<T>(ctor),
                 IgnoreDefaultFields = ignoreDefaultFields,
                 PolymorphicIndicateIndex = polymorphicFieldNumber,
+                PolymorphicFallbackToBaseType = fallbackToBaseType,
                 PolymorphicFields = polymorphicFields,
                 Fields = fields.OrderBy(x => x.Key).ToDictionary(x => x.Key, x => x.Value)
             };

--- a/Lagrange.Proto/ThrowHelper.cs
+++ b/Lagrange.Proto/ThrowHelper.cs
@@ -66,4 +66,24 @@ internal static class ThrowHelper
     [DoesNotReturn]
     [MethodImpl(MethodImplOptions.NoInlining)]
     public static void ThrowInvalidOperationException_InvalidNodesWireType(string fieldName) => throw new InvalidOperationException($"The wire type must be explicitly set for field {fieldName} as the wire type for the ProtoNode, ProtoValue, and ProtoArray types is not known at compile time, to set the wire type, use the NodesWireType Property in ProtoMember attribute");
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowInvalidOperationException_NullPolymorphicDiscriminator(Type type) => throw new InvalidOperationException($"The polymorphic discriminator field for type {type.Name} cannot be null. Please ensure that the field is set and has a valid value.");
+    
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowInvalidOperationException_DuplicatePolymorphicDiscriminator(Type type, object key) => throw new InvalidOperationException($"The polymorphic discriminator key '{key}' for type {type.Name} is duplicated. Please ensure that the keys are unique.");
+    
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowInvalidOperationException_PolymorphicFieldNotFirst(Type type, uint expected, uint actual) => throw new InvalidOperationException($"The polymorphic discriminator field for type {type.Name} must be the first field in the message. Expected field number {expected}, but found {actual}.");
+    
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowInvalidOperationException_FailedParsePolymorphicType(Type type, uint index) => throw new InvalidOperationException($"Failed to parse the polymorphic type from proto for type {type.Name} at '{index}'.");
+
+    [DoesNotReturn]
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    public static void ThrowInvalidOperationException_UnknownPolymorphicType(Type type, object polyTypeKey) => throw new InvalidOperationException($"Unknown polymorphic type '{polyTypeKey}' for base type {type.Name}. Please ensure that the polymorphic type is registered.");
 }


### PR DESCRIPTION
**Motivation**

Since the `PbElem` field of `CommonElem(53)` contains actual data, the ServiceType field is used to distinguish the type of data contained therein.

The TLVs also have this design model style.

It is hoped that the data structure can reflect this model design, making it easier to convert during serialization and deserialization.

**Current**

(Not Implemented CommonElem in V2)
In `Lagrange.Core`, directly read to a byte array and re-serialize.

**Reference**

Reference STJ's JsonDerivedTypeAttribute and JsonPolymorphicAttribute structures to achieve polymorphism.

**Example**

See [Lagrange.Proto.Test/ProtoPolymorphismTest.cs](/Lagrange.Proto.Test/ProtoPolymorphismTest.cs)

<details>

```csharp
[ProtoPolymorphic(FieldNumber = 1)]
[ProtoDerivedType(typeof(DerivedClassA), 2)]
[ProtoDerivedType(typeof(DerivedClassB), 3)]
public class BaseClass
{
    public BaseClass() : this(-1) { }

    public BaseClass(int identifier)
    {
        IdentifierProperty = identifier;
    }

    [ProtoMember(1)] public int IdentifierProperty { get; set; }
}

public class DerivedClassA() : BaseClass(2)
{
    [ProtoMember(2)] public string NameProperty { get; set; }
}

public class DerivedClassB() : BaseClass(3)
{
    [ProtoMember(2)] public float ValueProperty { get; set; }
}

BaseClass original = new DerivedClassA { NameProperty = "TestName" };
byte[] bytes = ProtoSerializer.Serialize(original);
BaseClass deserialized = ProtoSerializer.Deserialize<BaseClass>(bytes);
```


</details>


**To-do**

- [ ] Implement in `Lagrange.Proto.Generator`
- [ ] Optimize code performance


> Just a crazy idea