### PR TITLE
[Milky] Fix message cache logic

### DIFF
--- a/Lagrange.Milky/Utility/Cache/FifoCache.cs
+++ b/Lagrange.Milky/Utility/Cache/FifoCache.cs
@@ -26,12 +26,21 @@ public sealed class FifoCache<TKey, TValue>(int capacity) : ICache<TKey, TValue>
         {
             if (_cache.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
             {
+                node.Value = new KeyValuePair<TKey, TValue>(key, value);
                 _sorted.Remove(node);
-                _sorted.AddFirst(new LinkedListNode<KeyValuePair<TKey, TValue>>(new(key, value)));
+                _sorted.AddFirst(node);
             }
             else
             {
-                if (_cache.Count == _capacity) _sorted.RemoveLast();
+                if (_cache.Count == _capacity)
+                {
+                    var oldNode = _sorted.Last;
+                    if (oldNode != null)
+                    {
+                        _sorted.RemoveLast();
+                        _cache.Remove(oldNode.Value.Key);
+                    }
+                }
 
                 KeyValuePair<TKey, TValue> item = new(key, value);
                 node = _sorted.AddFirst(item);

--- a/Lagrange.Milky/Utility/Cache/LruCache.cs
+++ b/Lagrange.Milky/Utility/Cache/LruCache.cs
@@ -32,12 +32,21 @@ public sealed class LruCache<TKey, TValue>(int capacity) : ICache<TKey, TValue> 
         {
             if (_cache.TryGetValue(key, out LinkedListNode<KeyValuePair<TKey, TValue>>? node))
             {
+                node.Value = new KeyValuePair<TKey, TValue>(key, value);
                 _sorted.Remove(node);
-                _sorted.AddFirst(new LinkedListNode<KeyValuePair<TKey, TValue>>(new(key, value)));
+                _sorted.AddFirst(node);
             }
             else
             {
-                if (_cache.Count == _capacity) _sorted.RemoveLast();
+                if (_cache.Count == _capacity)
+                {
+                    var lastNode = _sorted.Last;
+                    if (lastNode != null)
+                    {
+                        _sorted.RemoveLast();
+                        _cache.Remove(lastNode.Value.Key);
+                    }
+                }
 
                 KeyValuePair<TKey, TValue> item = new(key, value);
                 node = _sorted.AddFirst(item);


### PR DESCRIPTION
`LruCache` 和 `FifoCache` 在缓存失效后没有同步将 `_cache` 中的节点删除。

---
当累计进入的缓存超过容量时，可能发生错误：
```csharp
LruCache<int, int> cache = new(5);
for (int i = 1; i <= 6; i++)
{
  cache.Put(i, i);
}

cache.Get(1);
```

```
System.InvalidOperationException: The LinkedList node does not belong to current LinkedList.
   at System.Collections.Generic.LinkedList`1.ValidateNode(LinkedListNode`1 node)
   at System.Collections.Generic.LinkedList`1.Remove(LinkedListNode`1 node)
   at Lagrange.Milky.Utility.Cache.LruCache`2.Get(TKey key)
```