### PR TITLE
[Milky] Fix wrong incoming type

### DIFF
--- a/Lagrange.Milky/Entity/Segment/ISegment.cs
+++ b/Lagrange.Milky/Entity/Segment/ISegment.cs
@@ -6,7 +6,7 @@ namespace Lagrange.Milky.Entity.Segment;
 [JsonDerivedType(typeof(TextIncomingSegment), typeDiscriminator: "text")]
 [JsonDerivedType(typeof(MentionIncomingSegment), typeDiscriminator: "mention")]
 [JsonDerivedType(typeof(MentionAllIncomingSegment), typeDiscriminator: "mention_all")]
-[JsonDerivedType(typeof(FaceIncomingSegment), typeDiscriminator: "face_incoming")]
+[JsonDerivedType(typeof(FaceIncomingSegment), typeDiscriminator: "face")]
 [JsonDerivedType(typeof(ReplyIncomingSegment), typeDiscriminator: "reply")]
 [JsonDerivedType(typeof(ImageIncomingSegment), typeDiscriminator: "image")]
 [JsonDerivedType(typeof(RecordIncomingSegment), typeDiscriminator: "record")]
@@ -15,6 +15,7 @@ namespace Lagrange.Milky.Entity.Segment;
 [JsonDerivedType(typeof(MarketFaceIncomingSegment), typeDiscriminator: "market_face")]
 [JsonDerivedType(typeof(LightAppIncomingSegment), typeDiscriminator: "light_app")]
 [JsonDerivedType(typeof(XmlIncomingSegment), typeDiscriminator: "xml")]
+[JsonDerivedType(typeof(FileIncomingSegment), typeDiscriminator: "file")]
 public interface IIncomingSegment
 {
     object? Data { get; }


### PR DESCRIPTION
## Motivation

The polymorphic json type resolve missmatch the Milky document.

## What's been done

1. Add `file` resolve to FileIncomingSegment
2. Rename `face_incoming` to `face` accoring to https://milky.ntqqrev.org/struct/IncomingSegment#type-face