### PR TITLE
fix(milky): compare bearer token spans safely

### DIFF
--- a/Lagrange.Milky/Api/MilkyHttpApiService.cs
+++ b/Lagrange.Milky/Api/MilkyHttpApiService.cs
@@ -131,7 +131,7 @@ public class MilkyHttpApiService(ILogger<MilkyHttpApiService> logger, IOptions<M
         string? authorization = context.Request.Headers["Authorization"];
         if (authorization == null) return false;
         if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) return false;
-        return authorization.AsSpan(7..).Equals(_token);
+        return authorization.AsSpan(7).SequenceEqual(_token);
     }
 
     private async Task<IApiHandler?> GetApiHandlerAsync(HttpListenerContext context, CancellationToken token)

--- a/Lagrange.Milky/Event/MilkyWebSocketEventService.cs
+++ b/Lagrange.Milky/Event/MilkyWebSocketEventService.cs
@@ -206,7 +206,7 @@ public class MilkyWebSocketEventService(ILogger<MilkyWebSocketEventService> logg
         if (authorization != null)
         {
             if (!authorization.StartsWith("Bearer ", StringComparison.OrdinalIgnoreCase)) return false;
-            return authorization.AsSpan(7..).Equals(_token);
+            return authorization.AsSpan(7).SequenceEqual(_token);
         }
 
         string? accessToken = context.Request.QueryString["access_token"];


### PR DESCRIPTION
## Summary
Fixes bearer token validation in the Milky HTTP API and WebSocket event service.

## Why
ReadOnlySpan<T> does not support object-based equality comparison. Using SequenceEqual avoids the runtime exception and correctly compares the bearer token contents.

Log:
```
fail: Lagrange.Milky.Event.MilkyWebSocketEventService[1428417503]
      b2c42b38-1699-436e-9643-19787c3db19c [127.0.0.1:46414](http://127.0.0.1:46414/) <!!> Handle http context failed
      System.NotSupportedException: Equals() on Span and ReadOnlySpan is not supported. Use operator== instead.
         at System.ReadOnlySpan`1.Equals(Object) + 0x27
         at Lagrange.Milky.Event.MilkyWebSocketEventService.ValidateAccessToken(HttpListenerContext context) + 0x195
         at Lagrange.Milky.Event.MilkyWebSocketEventService.<ValidateHttpContextAsync>d__17.MoveNext() + 0x2b8
      --- End of stack trace from previous location ---
         at Lagrange.Milky.Event.MilkyWebSocketEventService.<HandleHttpContextAsync>d__14.MoveNext() + 0x109
```

## Testing
Verified the affected authorization paths no longer use unsupported span equality
Confirmed the fix applies to both HTTP API and WebSocket token validation