### PR TITLE
fix(video): correct video upload protocol via highway

### DIFF
--- a/Lagrange.Core/Internal/Packets/Service/NTV2RichMedia.cs
+++ b/Lagrange.Core/Internal/Packets/Service/NTV2RichMedia.cs
@@ -158,7 +158,7 @@ internal static class NTV2RichMedia
             }
             case VideoEntity:
             {
-                info.Type.Type = 2; // unable to determine video type, skip
+                info.Type = new FileType { Type = 2 };
                 info.FileName = $"{md5}.mp4"; // default to mp4
                 break;
             }

--- a/Lagrange.Core/Message/Entities/VideoEntity.cs
+++ b/Lagrange.Core/Message/Entities/VideoEntity.cs
@@ -51,12 +51,13 @@ public class VideoEntity : RichMediaEntityBase
                 if (result.Ext != null)
                 {
                     result.Ext.Hash.FileSha1 = CalculateStreamBytes(Stream.Value);
-                    await context.HighwayContext.UploadFile(Stream.Value, 1001, ProtoHelper.Serialize(result.Ext));
+                    await context.HighwayContext.UploadFile(Stream.Value, 1005, ProtoHelper.Serialize(result.Ext));
                 }
 
                 if (result.SubExt != null)
                 {
-                    await context.HighwayContext.UploadFile(ThumbnailStream.Value, 1002, ProtoHelper.Serialize(result.SubExt));
+                    result.SubExt.Hash.FileSha1 = CalculateStreamBytes(ThumbnailStream.Value);
+                    await context.HighwayContext.UploadFile(ThumbnailStream.Value, 1006, ProtoHelper.Serialize(result.SubExt));
                 }
             }
             else
@@ -68,12 +69,13 @@ public class VideoEntity : RichMediaEntityBase
                 if (result.Ext != null)
                 {
                     result.Ext.Hash.FileSha1 = CalculateStreamBytes(Stream.Value);
-                    await context.HighwayContext.UploadFile(Stream.Value, 1005, ProtoHelper.Serialize(result.Ext));
+                    await context.HighwayContext.UploadFile(Stream.Value, 1001, ProtoHelper.Serialize(result.Ext));
                 }
 
                 if (result.SubExt != null)
                 {
-                    await context.HighwayContext.UploadFile(ThumbnailStream.Value, 1006, ProtoHelper.Serialize(result.SubExt));
+                    result.SubExt.Hash.FileSha1 = CalculateStreamBytes(ThumbnailStream.Value);
+                    await context.HighwayContext.UploadFile(ThumbnailStream.Value, 1002, ProtoHelper.Serialize(result.SubExt));
                 }
             }
         }


### PR DESCRIPTION
附上 ffmpeg 生成随机 150-200MB 的视频命令
```bash
ts=$(date +%s%N)
ffmpeg -hide_banner -loglevel error \
  -f lavfi -i "color=c=black:s=1280x720:r=30:d=600,format=yuv420p,noise=alls=80:allf=t+u,drawtext=text='UID-$ts':fontcolor=white:fontsize=80:x=20:y=20" \
  -f lavfi -i "anullsrc=channel_layout=stereo:sample_rate=44100" \
  -shortest -c:v libx264 -b:v 2500k -maxrate 3000k -bufsize 6000k -c:a aac -b:a 128k -f mp4 \
  "big-$ts.mp4" -y
```